### PR TITLE
Remove API key reference (never populated).

### DIFF
--- a/src/helpers/axios.js
+++ b/src/helpers/axios.js
@@ -6,10 +6,7 @@ export const zabApi = axios.create({
 });
 
 export const vatusaApi = axios.create({
-  baseURL: "https://api.vatusa.net/v2",
-  params: {
-    apikey: import.meta.env.VITE_VATUSA_API_KEY,
-  },
+  baseURL: "https://api.vatusa.net/v2"
 });
 
 export const vatusaApiAuth = axios.create({


### PR DESCRIPTION
## [#61] Remove Potentially Harmful Key Reference

---

### Summary

- Removes a bad key reference that could an expose an API key if it were configured in the infrastructure. 

---

### Testing

1. Verify solo certifications page in the instructor dashboard still operates correctly.

---

### Post-Deployment Validation

1. Verify solo certifications page in the instructor dashboard still operates correctly.

---

### Notes

- This API key was never actually set, there is no evidence that the key was ever leaked. 

---

Closes #61 