### PR TITLE
Change Controller Profile Certifications/Endorsements

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,7 +2,7 @@ name: Build and Deploy to Development
 
 on:
   push:
-    branches: [DD_controller_profile_cert_records]
+    branches: [development]
 
 jobs:
   build-docker-image:
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v2
         with:
-          ref: "DD_controller_profile_cert_records"
+          ref: "development"
       - name: Log in to container registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,7 +2,7 @@ name: Build and Deploy to Development
 
 on:
   push:
-    branches: [development]
+    branches: [DD_controller_profile_cert_records]
 
 jobs:
   build-docker-image:
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v2
         with:
-          ref: "development"
+          ref: "DD_controller_profile_cert_records"
       - name: Log in to container registry
         uses: docker/login-action@v1
         with:

--- a/src/views/admin/controllers/Activity.vue
+++ b/src/views/admin/controllers/Activity.vue
@@ -175,15 +175,12 @@ export default {
 			const hasCerts = certs.map(cert => cert.code);
 			let certsToShow = [];
 			certs.forEach(cert => {
-				if(cert.class === "major" || cert.class === "center") {
+				if(cert.class === "tier-one" || cert.class === "tier-two") {
 					certsToShow.push(cert);
-				} else {
-					const certPos = cert.code.slice(-3);
-					if(!hasCerts.includes(`p50${certPos}`)) {
-						certsToShow.push(cert);
-					}
 				}
 			});
+
+			certsToShow = certsToShow.sort((a, b) => a.class.localeCompare(b.class, 'en', { numeric: true }) || a.order - b.order)
 			return certsToShow;
 		},
 		sort(p) {
@@ -342,15 +339,11 @@ export default {
 			background: $cert_training;
 		}
 		
-		&.cert_center {
+		&.cert_tier-one {
 			background-color: $secondary-color-dark;
 		}
 
-		&.cert_major {
-			background: $secondary-color;
-		}
-
-		&.cert_minor {
+		&.cert_tier-two {
 			background: $secondary-color-light;
 		}
 	}

--- a/src/views/admin/controllers/Edit.vue
+++ b/src/views/admin/controllers/Edit.vue
@@ -132,13 +132,6 @@ export default {
 				oi: '',
 				vis: false,
 				certs: {
-					zab: false,
-					p50app: false,
-					p50twr: false,
-					p50gnd: false,
-					app: false,
-					twr: false,
-					gnd: false
 				},
 				roles: {
 					atm: false,

--- a/src/views/admin/controllers/Edit.vue
+++ b/src/views/admin/controllers/Edit.vue
@@ -35,44 +35,60 @@
 							<i v-else class="material-icons red-text text-darken-1">remove_circle</i>
 						</div>
 					</div>
-					<div class="input-field col s12">
-						<label for="certs" class="active">Certifications</label>
+					<div class="input-field col s5">
+						<label for="certs" class="active">Endorsements</label>
+						<div id="certs_container">
+                            <span 
+                                id="enroute" 
+                                :class="{active: form.certs.enroute}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">Center</span>
+                            <span 
+                                id="p50" 
+                                :class="{active: form.certs.p50}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">P50</span>
+                            <span 
+                                id="kphxtower" 
+                                :class="{active: form.certs.kphxtower}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">KPHX TWR</span>
+							<span 
+                                id="kphxground" 
+                                :class="{active: form.certs.kphxground}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">KPHX GND</span>
+						</div>
+						<div id="tier_one_explainer">
+							<p class="endorsement_category_explainer">Tier One</p>
+						</div>
+					</div>
+					<div class="input-field col s7">
 						<div id="certs_container">
 							<span 
-								id="zab" 
-								:class="{active: form.certs.zab}" 
-								class="cert cert_center" 
-								@click="toggleCert">Albuquerque Center</span>
+								id="kabq" 
+								:class="{active: form.certs.kabq}" 
+								class="cert cert_minor m-1"
+								style="margin-left: 0" 
+								@click="toggleCert">KABQ</span>
 							<span 
-								id="p50app" 
-								:class="{active: form.certs.p50app}" 
-								class="cert cert_major" 
-								@click="toggleCert">Major Approach</span>
+								id="kflg" 
+								:class="{active: form.certs.kflg}" 
+								class="cert cert_minor tier_two_button" 
+								@click="toggleCert">KFLG</span>
 							<span 
-								id="p50twr" 
-								:class="{active: form.certs.p50twr}" 
-								class="cert cert_major" 
-								@click="toggleCert">Major Tower</span>
+								id="kluf" 
+								:class="{active: form.certs.kluf}" 
+								class="cert cert_minor tier_two_button" 
+								@click="toggleCert">KLUF</span>
 							<span 
-								id="p50gnd" 
-								:class="{active: form.certs.p50gnd}" 
-								class="cert cert_major" 
-								@click="toggleCert">Major Ground</span>
-							<span 
-								id="app" 
-								:class="{active: form.certs.app}" 
-								class="cert cert_minor" 
-								@click="toggleCert">Minor Approach</span>
-							<span 
-								id="twr" 
-								:class="{active: form.certs.twr}" 
-								class="cert cert_minor" 
-								@click="toggleCert">Minor Tower</span>
-							<span 
-								id="gnd" 
-								:class="{active: form.certs.gnd}" 
-								class="cert cert_minor" 
-								@click="toggleCert">Minor Ground</span>
+								id="ksaf" 
+								:class="{active: form.certs.ksaf}" 
+								class="cert cert_minor tier_two_button" 
+								@click="toggleCert">KSAF</span>
+						</div>
+						<div id="tier_two_explainer">
+							<p class="endorsement_category_explainer">Tier Two</p>
 						</div>
 					</div>
 					<div class="input-field col s12">
@@ -255,5 +271,14 @@ export default {
 
 #certs_container, #roles_container {
 	margin-top: 5px;
+}
+
+.endorsement_category_explainer {
+	text-style: italic;
+	font-size: 10px;
+}
+
+.tier_two_button {
+	margin: 0 5px;
 }
 </style>

--- a/src/views/controllers/Profile.vue
+++ b/src/views/controllers/Profile.vue
@@ -131,15 +131,13 @@ export default {
 			if(!certs) return [];
 			const hasCerts = certs.map((cert) => cert.code);
 			let certsToShow = [];
-			certs.forEach((cert) => {
-				if(cert.class === "major" || cert.class === "center") certsToShow.push(cert);
-				else {
-					const certPos = cert.code.slice(-3);
-					if(!hasCerts.includes(`p50${certPos}`)) {
-						certsToShow.push(cert);
-					}
+			certs.forEach(cert => {
+				if(cert.class === "tier-one" || cert.class === "tier-two") {
+					certsToShow.push(cert);
 				}
 			});
+			
+			certsToShow = certsToShow.sort((a, b) => a.class.localeCompare(b.class, 'en', { numeric: true }) || a.order - b.order)
 			return certsToShow;
 		},
 		sec2hm(secs) {
@@ -215,15 +213,11 @@ export default {
 		background: $cert_training;
 	}
 	
-	&.cert_center {
+	&.cert_tier-one {
 		background-color: $secondary-color-dark;
 	}
 
-	&.cert_major {
-		background: $secondary-color;
-	}
-
-	&.cert_minor {
+	&.cert_tier-two {
 		background: $secondary-color-light;
 	}
 }

--- a/src/views/controllers/Roster.vue
+++ b/src/views/controllers/Roster.vue
@@ -182,16 +182,13 @@ export default {
       if (!certs) return [];
       const hasCerts = certs.map((cert) => cert.code);
       let certsToShow = [];
-      certs.forEach((cert) => {
-        if (cert.class === "major" || cert.class === "center")
-          certsToShow.push(cert);
-        else {
-          const certPos = cert.code.slice(-3);
-          if (!hasCerts.includes(`p50${certPos}`)) {
-            certsToShow.push(cert);
-          }
-        }
-      });
+			certs.forEach(cert => {
+				if(cert.class === "tier-one" || cert.class === "tier-two") {
+					certsToShow.push(cert);
+				}
+			});
+
+      certsToShow = certsToShow.sort((a, b) => a.class.localeCompare(b.class, 'en', { numeric: true }) || a.order - b.order)
       return certsToShow;
     },
   },
@@ -272,17 +269,13 @@ td {
     background: $cert_training;
   }
 
-  &.cert_center {
-    background-color: $secondary-color-dark;
-  }
+	&.cert_tier-one {
+		background-color: $secondary-color-dark;
+	}
 
-  &.cert_major {
-    background: $secondary-color;
-  }
-
-  &.cert_minor {
-    background: $secondary-color-light;
-  }
+	&.cert_tier-two {
+		background: $secondary-color-light;
+	}
 }
 
 .tooltipped {

--- a/src/views/dashboard/training/Request.vue
+++ b/src/views/dashboard/training/Request.vue
@@ -127,7 +127,7 @@ export default {
 	},
 	computed: {
 		filteredMilestones() {
-			const certs = this.user.data.certCodes;
+			const userCerts = this.user.data.certCodes;
 			const rating = this.user.data.rating;
 
 			if(this.milestones) {
@@ -135,19 +135,21 @@ export default {
 				const majorPrerequisites = ["obs", "kabq", "kphxground", "kphxtower", "p50"];
 
 				let milestonesShowed = this.milestones.filter((milestone) => {
-					if(this.user.data.vis) return (milestone.certCode.substring(0, 3) === "vis" && milestone.rating <= rating) || milestone.code === "GT1";
-					else {
-						return (  // This is still slightly hard to understand.  It returns the milestones that haven't been completed yet for the rating, or the P50 equivelant (if no major cert has been attained yet) and next rating's milestones, or center milestones if all other certs have been attained.
-							!certs.includes(milestone.certCode) &&
-							(
-								milestone.code === "GT1" ||
-								(milestone.certCode.substring(0, 3) === "p50" && certs.includes(milestone.certCode.slice(-3)) && certs.includes(majorPrerequisites[milestone.rating - 1])) || 
-								(milestone.certCode.substring(0, 3) !== "p50" && (certs.includes(minorPrerequisites[milestone.rating - 1]) || (milestone.rating === "1" && certs.length === 0)) && milestone.certCode !== "enroute") ||
-								(milestone.certCode === "enroute" && certs.includes("p50"))
-							) && 
-							milestone.certCode.substring(0, 3) !== "vis"
-						);
+					const milestoneAvailableAtRating = milestone.availableAtRatings.includes(rating); // Milestones available for rating.
+					let userHasTierOneForCurrentRating = false;
+
+					// See if the user has a tier one cert for their current rating.
+					if (rating == 2) {
+						userHasTierOneForCurrentRating = userCerts.includes('kphxground');
+					} else if (rating == 3) {
+						userHasTierOneForCurrentRating = userCerts.includes('kphxtower');
 					}
+					else if (rating == 4) {
+						userHasTierOneForCurrentRating = userCerts.includes('p50');
+					}
+
+					// Return milestones available to user (hide tier one if they have the cert already).
+					return milestoneAvailableAtRating && !(milestone.hiddenWhenControllerHasTierOne && userHasTierOneForCurrentRating)
 				});
 
 				return milestonesShowed;

--- a/src/views/dashboard/training/Request.vue
+++ b/src/views/dashboard/training/Request.vue
@@ -131,8 +131,8 @@ export default {
 			const rating = this.user.data.rating;
 
 			if(this.milestones) {
-				const minorPrerequisites = ["obs", "gnd", "twr", "app"];
-				const majorPrerequisites = ["obs", "gnd", "p50gnd", "p50twr", "p50app"];
+				const minorPrerequisites = ["obs"];
+				const majorPrerequisites = ["obs", "kabq", "kphxground", "kphxtower", "p50"];
 
 				let milestonesShowed = this.milestones.filter((milestone) => {
 					if(this.user.data.vis) return (milestone.certCode.substring(0, 3) === "vis" && milestone.rating <= rating) || milestone.code === "GT1";
@@ -142,8 +142,8 @@ export default {
 							(
 								milestone.code === "GT1" ||
 								(milestone.certCode.substring(0, 3) === "p50" && certs.includes(milestone.certCode.slice(-3)) && certs.includes(majorPrerequisites[milestone.rating - 1])) || 
-								(milestone.certCode.substring(0, 3) !== "p50" && (certs.includes(minorPrerequisites[milestone.rating - 1]) || (milestone.rating === "1" && certs.length === 0)) && milestone.certCode !== "zab") ||
-								(milestone.certCode === "zab" && certs.includes("p50app"))
+								(milestone.certCode.substring(0, 3) !== "p50" && (certs.includes(minorPrerequisites[milestone.rating - 1]) || (milestone.rating === "1" && certs.length === 0)) && milestone.certCode !== "enroute") ||
+								(milestone.certCode === "enroute" && certs.includes("p50"))
 							) && 
 							milestone.certCode.substring(0, 3) !== "vis"
 						);

--- a/src/views/instructor/controllers/Edit.vue
+++ b/src/views/instructor/controllers/Edit.vue
@@ -31,44 +31,60 @@
 						<input id="oi" type="text" :value="form.oi" maxlength="2" disabled>
 						<label for="oi" class="active">Operating Initials</label>
 					</div>
-					<div class="input-field col s12">
-						<label for="certs" class="active">Certifications</label>
+<div class="input-field col s5">
+						<label for="certs" class="active">Endorsements</label>
+						<div id="certs_container">
+                            <span 
+                                id="enroute" 
+                                :class="{active: form.certs.enroute}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">Center</span>
+                            <span 
+                                id="p50" 
+                                :class="{active: form.certs.p50}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">P50</span>
+                            <span 
+                                id="kphxtower" 
+                                :class="{active: form.certs.kphxtower}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">KPHX TWR</span>
+							<span 
+                                id="kphxground" 
+                                :class="{active: form.certs.kphxground}" 
+                                class="cert cert_major" 
+                                @click="toggleCert">KPHX GND</span>
+						</div>
+						<div id="tier_one_explainer">
+							<p class="endorsement_category_explainer">Tier One</p>
+						</div>
+					</div>
+					<div class="input-field col s7">
 						<div id="certs_container">
 							<span 
-								id="zab" 
-								:class="{active: form.certs.zab}" 
-								class="cert cert_center" 
-								@click="toggleCert">Albuquerque Center</span>
+								id="kabq" 
+								:class="{active: form.certs.kabq}" 
+								class="cert cert_minor m-1"
+								style="margin-left: 0" 
+								@click="toggleCert">KABQ</span>
 							<span 
-								id="p50app" 
-								:class="{active: form.certs.p50app}" 
-								class="cert cert_major" 
-								@click="toggleCert">Major Approach</span>
+								id="kflg" 
+								:class="{active: form.certs.kflg}" 
+								class="cert cert_minor tier_two_button" 
+								@click="toggleCert">KFLG</span>
 							<span 
-								id="p50twr" 
-								:class="{active: form.certs.p50twr}" 
-								class="cert cert_major" 
-								@click="toggleCert">Major Tower</span>
+								id="kluf" 
+								:class="{active: form.certs.kluf}" 
+								class="cert cert_minor tier_two_button" 
+								@click="toggleCert">KLUF</span>
 							<span 
-								id="p50gnd" 
-								:class="{active: form.certs.p50gnd}" 
-								class="cert cert_major" 
-								@click="toggleCert">Major Ground</span>
-							<span 
-								id="app" 
-								:class="{active: form.certs.app}" 
-								class="cert cert_minor" 
-								@click="toggleCert">Minor Approach</span>
-							<span 
-								id="twr" 
-								:class="{active: form.certs.twr}" 
-								class="cert cert_minor" 
-								@click="toggleCert">Minor Tower</span>
-							<span 
-								id="gnd" 
-								:class="{active: form.certs.gnd}" 
-								class="cert cert_minor" 
-								@click="toggleCert">Minor Ground</span>
+								id="ksaf" 
+								:class="{active: form.certs.ksaf}" 
+								class="cert cert_minor tier_two_button" 
+								@click="toggleCert">KSAF</span>
+						</div>
+						<div id="tier_two_explainer">
+							<p class="endorsement_category_explainer">Tier Two</p>
 						</div>
 					</div>
 					<div class="input-field col s12">
@@ -111,13 +127,6 @@ export default {
 				oi: '',
 				vis: false,
 				certs: {
-					zab: false,
-					p50app: false,
-					p50twr: false,
-					p50gnd: false,
-					app: false,
-					twr: false,
-					gnd: false
 				},
 				roles: {
 					atm: false,
@@ -237,5 +246,10 @@ export default {
 	.cert {
 		pointer-events: none;
 	}
+}
+
+.endorsement_category_explainer {
+	text-style: italic;
+	font-size: 10px;
 }
 </style>


### PR DESCRIPTION
## Change Controller Profile Certifications/Endorsements

---

### Summary
- Modifies site logic to change away from "Major/Minor" certs to "Tier 1/Tier 2" certifications.
    - and dependency logic relying on certifications.

---

### Testing

1. Verify endorsements match the equivalents in the existing site, can be updated, etc,
2. Verify training milestone logic honors these when deciding which sessions to show. 

---

### Post-Deployment Validation

- Testing section verified against production DB contents.

---
