### PR TITLE
Allow EC Read Feedback Access

### DIFF
--- a/src/views/admin/AdminSidebar.vue
+++ b/src/views/admin/AdminSidebar.vue
@@ -25,7 +25,7 @@
 				Events
 				<div class="secondary-content"><i class="material-icons">event</i></div>
 			</router-link>
-			<router-link to="/admin/feedback" class="collection-item" v-if="requiresAuth(['atm', 'datm', 'ta'])">
+			<router-link to="/admin/feedback" class="collection-item" v-if="requiresAuth(['atm', 'datm', 'ta', 'ec'])">
 				Feedback
 				<div class="secondary-content"><i class="material-icons">feedback</i></div>
 			</router-link>

--- a/src/views/admin/feedback/Index.vue
+++ b/src/views/admin/feedback/Index.vue
@@ -69,7 +69,7 @@
 									</div>
 								</div>
 							</div>
-							<div class="modal-footer">
+							<div class="modal-footer" v-if="requiresAuth(['atm', 'datm', 'ta'])">
 								<a href="#!" class="waves-effect waves-light btn" @click="approveFeedback(feedback._id)">Approve</a>
 								<a href="#!" class="waves-effect waves-light btn-flat" @click="rejectFeedback(feedback._id)">Reject</a>
 							</div>
@@ -85,6 +85,7 @@
 <script>
 import {zabApi} from '@/helpers/axios.js';
 import RecentFeedback from './Recent.vue';
+import { mapState } from 'vuex';
 
 export default {
 	name: 'Feedback',
@@ -107,6 +108,14 @@ export default {
 		});
 	},
 	methods: {
+		requiresAuth(roles) {
+			const havePermissions = roles.some(r => this.user.data.roleCodes.includes(r));
+			if(havePermissions) {
+				return true;
+			} else {
+				return false;
+			}
+		},
 		async getUnapproved() {
 			const {data} = await zabApi.get('/feedback/unapproved');
 			this.unapproved = data.data;
@@ -149,6 +158,11 @@ export default {
 			const ratings = ['Poor', 'Below Average', 'Average', 'Above Average', 'Excellent'];
 			return ratings[rating - 1];
 		}
+	},
+	computed: {
+		...mapState('user', [
+			'user'
+		])
 	}
 };
 </script>


### PR DESCRIPTION
## Allow EC Read Feedback Access

---

### Summary

- Allows EC to read feedback, but not edit it.
- Closes https://github.com/zabartcc/issue-reporting/issues/13
---

### Testing

1. Take EC role.
2. Verify you can view feedback.
3. Verify you have no buttons to approve/deny feedback.

---

### Post-Deployment Validation

- Repeat testing.

---

Has companion PR https://github.com/zabartcc/api/pull/30 needs to be released simulatenously. 
