### PR TITLE
Fix training schedule UI

### DIFF
--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -178,3 +178,7 @@ select:not(.materialize-select):not(.browser-default) {
 .table_wrapper {
 	overflow: auto;
 }
+
+.flatpickr-monthDropdown-months {
+	opacity: 1;
+}

--- a/src/views/admin/controllers/Activity.vue
+++ b/src/views/admin/controllers/Activity.vue
@@ -67,7 +67,7 @@
 										</span>
 									</div>
 									<div class="certifications training_request" v-if="controller.rating >= 0">
-										Controller has made <b>{{controller.totalRequests}}</b> training request(s) in the last 60 days
+										Controller has made <b>{{controller.totalRequests}}</b> training request(s) in the last 90 days
 									</div>
 								</div>
 							</router-link>
@@ -126,7 +126,7 @@ export default {
 	methods: {
 		async getActivity() {
 			const d = new Date();
-			this.chkDate = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - 61));
+			this.chkDate = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - 91));
 			const {data: reportData} = await zabApi.get('/stats/activity');
 			this.report = reportData.data;
 		},


### PR DESCRIPTION
## [Issue Reporting 14](https://github.com/zabartcc/issue-reporting/issues/14)

### Summary

This PR fixes the blank month button on the training request page. I had to make it a global style because scoped styles in vue don't penetrate into child components from external libraries like flatpickr.

---

### What it Looks Like
![image](https://github.com/zabartcc/ui/assets/97543307/f71e5485-4903-4566-9858-453a4489104d)

---

### Testing

1. Login and go to /dash/training/new
2. Edit start or end time