### PR TITLE
Fix blank month for training requests

### DIFF
--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -178,3 +178,7 @@ select:not(.materialize-select):not(.browser-default) {
 .table_wrapper {
 	overflow: auto;
 }
+
+.flatpickr-monthDropdown-months {
+	opacity: 1;
+}


### PR DESCRIPTION
## [Issue Reporting 14](https://github.com/zabartcc/issue-reporting/issues/14)

### Summary

This PR fixes the blank month button on the training request page. I had to make it a global style because scoped styles in vue don't penetrate into child components from external libraries like flatpickr.

---

### What it Looks Like
![image](https://github.com/zabartcc/ui/assets/97543307/f71e5485-4903-4566-9858-453a4489104d)

---

### Testing

1. Login and go to /dash/training/new
2. Edit start or end time