### PR TITLE
Add a page to view all picked up sessions

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -146,6 +146,10 @@ const routes = [
         component: () => import("../views/instructor/training/Sessions.vue"),
       },
       {
+        path: "training/sessions/picked-up",
+        component: () => import("../views/instructor/training/PickedUpSessions.vue"),
+      },
+      {
         path: "training/sessions/:cid",
         component: () =>
           import("../views/instructor/training/UserSessions.vue"),

--- a/src/views/instructor/InstructorSidebar.vue
+++ b/src/views/instructor/InstructorSidebar.vue
@@ -21,6 +21,10 @@
 				Training Sessions
 				<div class="secondary-content"><i class="material-icons">event_note</i></div>
 			</router-link>
+      <router-link to="/ins/training/sessions/picked-up" class="collection-item">
+        Picked-up Sessions
+        <div class="secondary-content"><i class="material-icons">groups</i></div>
+      </router-link>
 		</div>
 	</div>
 </template>

--- a/src/views/instructor/training/PickedUpSessions.vue
+++ b/src/views/instructor/training/PickedUpSessions.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="card">
+    <div class="card-content">
+      <div class="card-title">All Picked-Up Training Sessions</div>
+    </div>
+    <div v-if="!sessions" class="loading_container">
+      <Spinner />
+    </div>
+    <div v-else-if="!sessions.length" class="no_sessions">
+      There are no picked-up training sessions.
+    </div>
+    <div class="sessions_wrapper" v-else>
+      <table class="sessions_list striped">
+        <thead class="sessions_list_head">
+        <tr>
+          <th>Student</th>
+          <th>Milestone</th>
+          <th>Instructor</th>
+          <th>Start</th>
+          <th>End</th>
+        </tr>
+        </thead>
+        <tbody class="sessions_list_row">
+        <tr v-for="(session) in sessions" :key="session._id">
+          <td>{{ session.student ? session.student.fname + ' ' + session.student.lname : 'No student assigned' }}</td>
+          <td>{{ session.milestone?.name }}</td>
+          <td>{{ session.instructor ? session.instructor.fname + ' ' + session.instructor.lname : 'No instructor assigned' }}</td>
+          <td>{{ formatDateTime(session.startTime) }}</td>
+          <td>{{ formatDateTime(session.endTime) }}</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { zabApi } from '@/helpers/axios.js';
+
+export default {
+  name: 'PickedUpSessions',
+  data() {
+    return {
+      sessions: null
+    };
+  },
+  async mounted() {
+    await this.fetchPickedUpSessions();
+  },
+  methods: {
+    async fetchPickedUpSessions() {
+      try {
+        const { data } = await zabApi.get(`/training/session/picked-up`);
+        this.sessions = data.data;
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    formatDateTime(value) {
+      const d = new Date(value);
+      return d.toLocaleString('en-US', {
+        month: 'long', day: 'numeric', year: 'numeric',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+        timeZone: 'UTC', hour12: false
+      });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.no_sessions {
+  font-style: italic;
+  margin-top: -1em;
+  padding: 0 1em 1em 1em;
+}
+</style>


### PR DESCRIPTION
## [Issue Reporting 7](https://github.com/zabartcc/issue-reporting/issues/7)

### Summary

This PR adds a page for training staff to view all picked up requests.

---

### What it Looks Like
![image](https://github.com/zabartcc/ui/assets/97543307/37970ab2-e5cf-453a-b57f-c8eb7bf355e2)
---

### Testing
1. Login as an account with a training role and go to /ins/training/sessions/picked-up
---
