### PR TITLE
Update Training Links

### DIFF
--- a/src/views/dashboard/DashSidebar.vue
+++ b/src/views/dashboard/DashSidebar.vue
@@ -13,7 +13,7 @@
 				IDS
 				<div class="secondary-content"><i class="material-icons">computer</i></div>
 			</router-link>
-			<router-link to="/dash/training" class="collection-item">
+			<router-link to="https://training.zabartcc.net/" class="collection-item">
 				Training Sessions
 				<div class="secondary-content"><i class="material-icons">insert_invitation</i></div>
 			</router-link>

--- a/src/views/dashboard/training/Index.vue
+++ b/src/views/dashboard/training/Index.vue
@@ -3,7 +3,7 @@
 		<div class="card-content">
 			<div class="row row_no_margin">
 				<div class="card-title col s8"><span class="card-title">Training Requests</span></div>
-				<div class="col s4"><router-link to="/dash/training/new"><span class="btn new_event_button right">Request</span></router-link></div>
+				<div class="col s4"><router-link to="https://training.zabartcc.net/"><span class="btn new_event_button right">Request</span></router-link></div>
 			</div>
 		</div>
 		<div class="loading_container" v-if="!upcomingSessions">

--- a/src/views/instructor/InstructorSidebar.vue
+++ b/src/views/instructor/InstructorSidebar.vue
@@ -13,11 +13,11 @@
 				Solo Certifications
 				<div class="secondary-content"><i class="material-icons">streetview</i></div>
 			</router-link>
-			<router-link to="/ins/training/requests" class="collection-item">
+			<router-link to="https://training.zabartcc.net/" class="collection-item">
 				Training Requests
 				<div class="secondary-content"><i class="material-icons">event</i></div>
 			</router-link>
-			<router-link to="/ins/training/sessions" class="collection-item">
+			<router-link to="https://training.zabartcc.net/" class="collection-item">
 				Training Sessions
 				<div class="secondary-content"><i class="material-icons">event_note</i></div>
 			</router-link>


### PR DESCRIPTION
## Update Training Links

---

### Summary

* Modifies old training links in the site to hyperlink to the new training site instead of the website's built-in training system.

---

### Testing

1. Verify:
![image](https://github.com/user-attachments/assets/eb6affeb-1c09-438e-ad55-f209c49bbfb5)

---

### Post-Deployment Validation

Repeat testing.

---
